### PR TITLE
add status_category column to jira_issue table

### DIFF
--- a/docs/tables/jira_issue.md
+++ b/docs/tables/jira_issue.md
@@ -91,13 +91,6 @@ where
   sprint_ids @> '2';
 ```
 
-### Status and Status Category
-You can use the field `status` or `status_category` to list issues in a particular workflow status. 
-
-The difference is that `status` is the custom name you define for a `status_category` in each Jira workflow that is fixed: `To do`, `In Progress`, and `Done`. Every `status` belongs to one of those `status_category`.
-
-For example, for `status_category` = `Done`, maybe in your workflow you defined possible statuses `Done` and `Wont Do`, both are `Done` status category that you can filter using that `status_category`. `status_category` is also useful when filtering across more than 1 project, as every project could be using their own workflow with different `status` names. 
-
 #### List all issues in status category 'Done'
 
 ```sql

--- a/docs/tables/jira_issue.md
+++ b/docs/tables/jira_issue.md
@@ -133,7 +133,7 @@ where
 #### List all possible status for each status_category for a speficic project
 
 ```sql
-select
+select distinct
   project_key,
   status_category,
   status

--- a/docs/tables/jira_issue.md
+++ b/docs/tables/jira_issue.md
@@ -98,7 +98,7 @@ The difference is that `status` is the custom name you define for a `status_cate
 
 For example, for `status_category` = `Done`, maybe in your workflow you defined possible statuses `Done` and `Wont Do`, both are `Done` status category that you can filter using that `status_category`. `status_category` is also useful when filtering across more than 1 project, as every project could be using their own workflow with different `status` names. 
 
-#### List all issues 'Done' (status_category)
+#### List all issues in status category 'Done'
 
 ```sql
 select
@@ -114,7 +114,7 @@ where
   status_category = 'Done';
 ```
 
-#### List all issues Done (status)
+#### List all issues in status Waiting for Support
 
 ```sql
 select
@@ -127,6 +127,20 @@ select
 from
   jira_issue
 where
-  status = 'Done' and 
-  status = 'Wont do' 
+  status = 'Waiting for support'
+```
+
+#### List all possible status for each status_category for a speficic project
+
+```sql
+select
+  project_key,
+  status_category,
+  status
+from
+  jira_issue
+where
+  project_key = 'PROJECT-KEY'
+order by
+  status_category
 ```

--- a/docs/tables/jira_issue.md
+++ b/docs/tables/jira_issue.md
@@ -135,5 +135,5 @@ from
 where
   project_key = 'PROJECT-KEY'
 order by
-  status_category
+  status_category;
 ```

--- a/docs/tables/jira_issue.md
+++ b/docs/tables/jira_issue.md
@@ -90,3 +90,43 @@ from
 where
   sprint_ids @> '2';
 ```
+
+### Status and Status Category
+You can use the field `status` or `status_category` to list issues in a particular workflow status. 
+
+The difference is that `status` is the custom name you define for a `status_category` in each Jira workflow that is fixed: `To do`, `In Progress`, and `Done`. Every `status` belongs to one of those `status_category`.
+
+For example, for `status_category` = `Done`, maybe in your workflow you defined possible statuses `Done` and `Wont Do`, both are `Done` status category that you can filter using that `status_category`. `status_category` is also useful when filtering across more than 1 project, as every project could be using their own workflow with different `status` names. 
+
+#### List all issues 'Done' (status_category)
+
+```sql
+select
+  id,
+  key,
+  summary,
+  status,
+  status_category,
+  assignee_display_name
+from
+  jira_issue
+where
+  status_category = 'Done';
+```
+
+#### List all issues Done (status)
+
+```sql
+select
+  id,
+  key,
+  summary,
+  status,
+  status_category,
+  assignee_display_name
+from
+  jira_issue
+where
+  status = 'Done' and 
+  status = 'Wont do' 
+```

--- a/docs/tables/jira_issue.md
+++ b/docs/tables/jira_issue.md
@@ -120,7 +120,7 @@ select
 from
   jira_issue
 where
-  status = 'Waiting for support'
+  status = 'Waiting for support';
 ```
 
 #### List all possible status for each status_category for a speficic project

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -40,6 +40,7 @@ func tableIssue(_ context.Context) *plugin.Table {
 				{Name: "reporter_display_name", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "resolution_date", Require: plugin.Optional, Operators: []string{"=", ">", ">=", "<=", "<"}},
 				{Name: "status", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "status_category", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "type", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "updated", Require: plugin.Optional, Operators: []string{"=", ">", ">=", "<=", "<"}},
 			},
@@ -79,6 +80,12 @@ func tableIssue(_ context.Context) *plugin.Table {
 				Description: "Json object containing important subfields info the issue.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Fields.Status.Name"),
+			},
+			{
+				Name:        "status_category",
+				Description: "The status category (Open, In Progress, Done) the ticket status belonngs",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Fields.Status.StatusCategory.Name"),
 			},
 			{
 				Name:        "epic_key",


### PR DESCRIPTION
Status Category in Jira is fixed: In Progress, To Do or Done.  On the other hand, status is custom based on the workflow. 

So if you need to list all Open tickets, you will need to know those custom statuses for your project, which is not always possible, and statuses can change from one project to another. That's why we can use status_category, which is always fixed for any project and workflow. 

# Example query results
<details>
  <summary>Results</summary>
  
```
select status, status_category from local_jira.jira_issue
+-------------------------+-----------------+
| status                  | status_category |
+-------------------------+-----------------+
| Fixed                   | Done            |
| Open                    | To Do           |
| Fixed                   | Done            |
| Fixed                   | Done            |
| Open                    | To Do           |
| Sec Review              | In Progress     |
| Fixed                   | Done            |
| Risk Accepted           | Done            |
| In Progress             | In Progress     |
| Fixed                   | Done            |
| In Progress             | In Progress     |
| False Positive Accepted | Done            |
| Fixed                   | Done            |
| Fixed                   | Done            |
| Open                    | To Do           |
```
</details>


### Status and Status Category
You can use the field `status` or `status_category` to list issues in a particular workflow status. 

The difference is that `status` is the custom name you define for a `status_category` in each Jira workflow that is fixed: `To do`, `In Progress`, and `Done`. Every `status` belongs to one of those `status_category`.

For example, for `status_category` = `Done`, maybe in your workflow you defined possible statuses `Done` and `Wont Do`, both are `Done` status category that you can filter using that `status_category`. `status_category` is also useful when filtering across more than 1 project, as every project could be using their own workflow with different `status` names. 