### PR TITLE
Fix `epic_key` column in list call. Closes #75

### DIFF
--- a/jira/table_jira_epic.go
+++ b/jira/table_jira_epic.go
@@ -133,7 +133,7 @@ func listEpics(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 
 func getEpic(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
-	logger.Trace("getEpic")
+	logger.Debug("getEpic")
 
 	epicId := d.EqualsQuals["id"].GetInt64Value()
 	epicKey := d.EqualsQuals["key"].GetStringValue()

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -311,8 +311,8 @@ func getIssue(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 	logger := plugin.Logger(ctx)
 	logger.Trace("getIssue")
 
-	issueId := d.EqualsQuals["id"].GetStringValue()
-	key := d.EqualsQuals["key"].GetStringValue()
+	issueId := d.EqualsQualString("id")
+	key := d.EqualsQualString("key")
 
 	client, err := connect(ctx, d)
 	if err != nil {

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -307,7 +307,7 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 
 //// HYDRATE FUNCTION
 
-func getIssue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getIssue(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	logger.Trace("getIssue")
 

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -283,8 +283,8 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 		}
 
 		for _, issue := range issues {
-			plugin.Logger(ctx).Trace("Issue output.......", issue)
-			plugin.Logger(ctx).Trace("Issue names output----", names)
+			plugin.Logger(ctx).Debug("Issue output:", issue)
+			plugin.Logger(ctx).Debug("Issue names output:", names)
 			keys := map[string]string{
 				"epic":   getFieldKey(ctx, d, names, "Epic Link"),
 				"sprint": getFieldKey(ctx, d, names, "Sprint"),
@@ -309,7 +309,7 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 
 func getIssue(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
-	logger.Trace("getIssue")
+	logger.Debug("getIssue")
 
 	issueId := d.EqualsQualString("id")
 	key := d.EqualsQualString("key")
@@ -412,7 +412,7 @@ func getIssueTags(_ context.Context, d *transform.TransformData) (interface{}, e
 // getFieldKey:: get key for unknown expanded fields
 func getFieldKey(ctx context.Context, d *plugin.QueryData, names map[string]string, keyName string) string {
 
-	plugin.Logger(ctx).Trace("Check for keyName", names)
+	plugin.Logger(ctx).Debug("Check for keyName", names)
 	cacheKey := "issue-" + keyName
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		return cachedData.(string)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  key,
  id, 
  epic_key,
  project_key
from
  jira_issue
where
  key in ('SBT-1', 'SBT-2', 'SBT-3')
+-------+-------+----------+-------------+
| key   | id    | epic_key | project_key |
+-------+-------+----------+-------------+
| SBT-3 | 10052 | SBT-1    | SBT         |
| SBT-1 | 10050 | <null>   | SBT         |
| SBT-2 | 10051 | SBT-1    | SBT         |
+-------+-------+----------+-------------+

Time: 396ms. Rows fetched: 1. Hydrate calls: 0.
> select
  key,
  id,
  epic_key,
  project_key
from
  jira_issue
where
  project_key = 'SBT'
+-------+-------+----------+-------------+
| key   | id    | epic_key | project_key |
+-------+-------+----------+-------------+
| SBT-3 | 10052 | SBT-1    | SBT         |
| SBT-1 | 10050 | <null>   | SBT         |
| SBT-2 | 10051 | SBT-1    | SBT         |
+-------+-------+----------+-------------+

Time: 0.9s. Rows fetched: 3. Hydrate calls: 3.
```
</details>
