### PR TITLE
Add support for on-premise Jira instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ steampipe plugin install jira
 
 Configure your [credentials](https://hub.steampipe.io/plugins/turbot/jira#credentials) and [config file](https://hub.steampipe.io/plugins/turbot/jira#configuration).
 
-> Leave the username empty if you are using a Personal Access Token (PAT) on a
-[self-hosted Jira instance](https://github.com/andygrunwald/go-jira/#bearer---personal-access-tokens-self-hosted-jira).
+> The Personal Access Token (PAT) is used for
+[self-hosted Jira instances](https://github.com/andygrunwald/go-jira/#bearer---personal-access-tokens-self-hosted-jira).
+You should use the `personal_access_token` field instead of `token`.
 
 Configure your account details in `~/.steampipe/config/jira.spc`:
 
@@ -31,9 +32,10 @@ connection "jira" {
   plugin = jira
 
   # Authentication information
-  base_url = "https://your-domain.atlassian.net/"
-  username = "abcd@xyz.com"
-  token    = "8WqcdT0rvIZpCjtDqReF48B1"
+  base_url              = "https://your-domain.atlassian.net/"
+  username              = "abcd@xyz.com"
+  token                 = "8WqcdT0rvIZpCjtDqReF48B1"
+  personal_access_token = "MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
 }
 ```
 
@@ -43,6 +45,7 @@ Or through environment variables:
 export JIRA_URL=https://your-domain.atlassian.net/
 export JIRA_USER=abcd@xyz.com
 export JIRA_TOKEN=8WqcdT0rvIZpCjtDqReF48B1
+export JIRA_PERSONAL_ACCESS_TOKEN="MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
 ```
 
 Run steampipe:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ steampipe plugin install jira
 
 Configure your [credentials](https://hub.steampipe.io/plugins/turbot/jira#credentials) and [config file](https://hub.steampipe.io/plugins/turbot/jira#configuration).
 
+> Leave the username empty if you are using a Personal Access Token (PAT) on a
+[self-hosted Jira instance](https://github.com/andygrunwald/go-jira/#bearer---personal-access-tokens-self-hosted-jira).
+
 Configure your account details in `~/.steampipe/config/jira.spc`:
 
 ```hcl

--- a/config/jira.spc
+++ b/config/jira.spc
@@ -7,6 +7,7 @@ connection "jira" {
 
   # The user name to access the jira cloud instance
   # Can also be set with the `JIRA_USER` environment variable.
+  # Leave it empty if you are using a Personal Access Token (PAT)
   # username = "abcd@xyz.com"
 
   # Access Token for which to use for the API

--- a/config/jira.spc
+++ b/config/jira.spc
@@ -7,10 +7,15 @@ connection "jira" {
 
   # The user name to access the jira cloud instance
   # Can also be set with the `JIRA_USER` environment variable.
-  # Leave it empty if you are using a Personal Access Token (PAT)
   # username = "abcd@xyz.com"
 
   # Access Token for which to use for the API
   # Can also be set with the `JIRA_TOKEN` environment variable.
+  # You should leave it empty if you are using a Personal Access Token (PAT)
   # token = "8WqcdT0rvIZpCjtDqReF48B1"
+
+  # Personal Access Token for which to use for the API.
+  # This one isused in self-hosted Jira instances.
+  # Can also be set with the `JIRA_PERSONAL_ACCESS_TOKEN` environment variable.
+  # personal_access_token = "MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,18 +75,24 @@ connection "jira" {
 
   # The user name to access the jira cloud instance
   # Can also be set with the `JIRA_USER` environment variable.
-  # Leave it empty if you are using a Personal Access Token (PAT)
   # username = "abcd@xyz.com"
 
   # Access Token for which to use for the API
   # Can also be set with the `JIRA_TOKEN` environment variable.
+  # You should leave it empty if you are using a Personal Access Token (PAT)
   # token = "8WqcdT0rvIZpCjtDqReF48B1"
+
+  # Personal Access Token for which to use for the API.
+  # This one isused in self-hosted Jira instances.
+  # Can also be set with the `JIRA_PERSONAL_ACCESS_TOKEN` environment variable.
+  # personal_access_token = "MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
 }
 ```
 
 - `base_url` - The site url of your attlassian jira subscription.
-- `username` - Email address of agent user who have permission to access the API. Leave the it empty if you are using a Personal Access Token (PAT) on a [self-hosted Jira instance](https://github.com/andygrunwald/go-jira/#bearer---personal-access-tokens-self-hosted-jira).
+- `username` - Email address of agent user who have permission to access the API.
 - `token` - [API token](https://id.atlassian.com/manage-profile/security/api-tokens) for user's Atlassian account.
+- `personal_access_token` - [API PAT](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html) for self hosted Jira instances.
 
 Alternatively, you can also use the standard Jira environment variables to obtain credentials **only if other arguments (`base_url`, `username` and `token`) are not specified** in the connection:
 
@@ -94,6 +100,7 @@ Alternatively, you can also use the standard Jira environment variables to obtai
 export JIRA_URL=https://your-domain.atlassian.net/
 export JIRA_USER=abcd@xyz.com
 export JIRA_TOKEN=8WqcdT0rvIZpCjtDqReF48B1
+export JIRA_PERSONAL_ACCESS_TOKEN="MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
 ```
 
 ## Get involved

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,29 @@ export JIRA_TOKEN=8WqcdT0rvIZpCjtDqReF48B1
 export JIRA_PERSONAL_ACCESS_TOKEN="MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
 ```
 
+## Important note about self hosted Jira instances
+
+As reported in [this GH issue](https://github.com/turbot/steampipe-plugin-jira/pull/86#issuecomment-1697122416), there are some tables that don't work on self hosted Jira.
+
+| table                 | works |
+|-----------------------|:-----:|
+| jira_advanced_setting |   ❌  |
+| jira_backlog_issue    |   ✅  |
+| jira_board            |   ✅  |
+| jira_component        |   ❌  |
+| jira_dashboard        |   ❌  |
+| jira_epic             |   ❌  |
+| jira_global_setting   |   ❌  |
+| jira_group            |   ❌  |
+| jira_issue            |   ✅  |
+| jira_issue_type       |   ❌  |
+| jira_priority         |   ❌  |
+| jira_project          |   ❌  |
+| jira_project_role     |   ❌  |
+| jira_sprint           |   ✅  |
+| jira_user             |   ❌  |
+| jira_workflow         |   ❌  |
+
 ## Get involved
 
 - Open source: https://github.com/turbot/steampipe-plugin-jira

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ connection "jira" {
 
   # The user name to access the jira cloud instance
   # Can also be set with the `JIRA_USER` environment variable.
+  # Leave it empty if you are using a Personal Access Token (PAT)
   # username = "abcd@xyz.com"
 
   # Access Token for which to use for the API
@@ -84,7 +85,7 @@ connection "jira" {
 ```
 
 - `base_url` - The site url of your attlassian jira subscription.
-- `username` - Email address of agent user who have permission to access the API.
+- `username` - Email address of agent user who have permission to access the API. Leave the it empty if you are using a Personal Access Token (PAT) on a [self-hosted Jira instance](https://github.com/andygrunwald/go-jira/#bearer---personal-access-tokens-self-hosted-jira).
 - `token` - [API token](https://id.atlassian.com/manage-profile/security/api-tokens) for user's Atlassian account.
 
 Alternatively, you can also use the standard Jira environment variables to obtain credentials **only if other arguments (`base_url`, `username` and `token`) are not specified** in the connection:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0
+	github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.5.1
 )
 
@@ -38,7 +39,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3b
 github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/andygrunwald/go-jira v1.16.0 h1:PU7C7Fkk5L96JvPc6vDVIrd99vdPnYudHu4ju2c2ikQ=
 github.com/andygrunwald/go-jira v1.16.0/go.mod h1:UQH4IBVxIYWbgagc0LF/k9FRs9xjIiQ8hIcC6HfLwFU=
+github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a h1:qSrg15WORClvHQfGe9RyFiDG52MeEpVj5qEs6O7QBE4=
+github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a/go.mod h1:TrfsnL20VgD+KgEw4gbTYuSAPE8T1ZxjMCFBGgGvNvI=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3 h1:ZSTrOEhiM5J5RFxEaFvMZVEAM1KvT1YzbEOwB2EAGjA=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
@@ -321,8 +323,9 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=

--- a/jira/connection_config.go
+++ b/jira/connection_config.go
@@ -6,9 +6,10 @@ import (
 )
 
 type jiraConfig struct {
-	BaseUrl  *string `cty:"base_url"`
-	Username *string `cty:"username"`
-	Token    *string `cty:"token"`
+	BaseUrl             *string `cty:"base_url"`
+	Username            *string `cty:"username"`
+	Token               *string `cty:"token"`
+	PersonalAccessToken *string `cty:"personal_access_token"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -19,6 +20,9 @@ var ConfigSchema = map[string]*schema.Attribute{
 		Type: schema.TypeString,
 	},
 	"token": {
+		Type: schema.TypeString,
+	},
+	"personal_access_token": {
 		Type: schema.TypeString,
 	},
 }

--- a/jira/utils.go
+++ b/jira/utils.go
@@ -27,6 +27,7 @@ func connect(_ context.Context, d *plugin.QueryData) (*jira.Client, error) {
 	baseUrl := os.Getenv("JIRA_URL")
 	username := os.Getenv("JIRA_USER")
 	token := os.Getenv("JIRA_TOKEN")
+	personal_access_token := os.Getenv("JIRA_PERSONAL_ACCESS_TOKEN")
 
 	// Prefer config options given in Steampipe
 	jiraConfig := GetConfig(d.Connection)
@@ -40,20 +41,26 @@ func connect(_ context.Context, d *plugin.QueryData) (*jira.Client, error) {
 	if jiraConfig.Token != nil {
 		token = *jiraConfig.Token
 	}
+	if jiraConfig.PersonalAccessToken != nil {
+		personal_access_token = *jiraConfig.PersonalAccessToken
+	}
 
 	if baseUrl == "" {
 		return nil, errors.New("'base_url' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}
-	if token == "" {
-		return nil, errors.New("'token' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
+	if username == "" {
+		return nil, errors.New("'username' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
+	}
+	if token == "" && personal_access_token == "" {
+		return nil, errors.New("at least one of 'token' or 'personal_access_token' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}
 
 	var client *jira.Client
 	var err error
 
-	if username == "" {
+	if personal_access_token != "" {
 		// If the username is empty, let's assume the user is using a PAT
-		tokenProvider := on_premise.BearerAuthTransport{Token: token}
+		tokenProvider := on_premise.BearerAuthTransport{Token: personal_access_token}
 		client, err = jira.NewClient(tokenProvider.Client(), baseUrl)
 	} else {
 		tokenProvider := jira.BasicAuthTransport{

--- a/jira/utils.go
+++ b/jira/utils.go
@@ -54,6 +54,9 @@ func connect(_ context.Context, d *plugin.QueryData) (*jira.Client, error) {
 	if token == "" && personal_access_token == "" {
 		return nil, errors.New("at least one of 'token' or 'personal_access_token' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}
+	if token != "" && personal_access_token != "" {
+		return nil, errors.New("'token' and 'personal_access_token' are both set, please only use one. Edit your connection configuration file and then restart Steampipe")
+	}
 
 	var client *jira.Client
 	var err error


### PR DESCRIPTION
Adding support for on-premise Jira instances. I made use of the [Bearer PAT](https://github.com/andygrunwald/go-jira/#bearer---personal-access-tokens-self-hosted-jira) from the parent Jira package.

On self-hosted Jira instances the username is not needed for API calls.
