### PR TITLE
Fix sprint type could be string and map

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -369,8 +369,9 @@ func extractSprintIds(ctx context.Context, d *transform.TransformData) (interfac
 	}
 	var sprintIds []interface{}
 	for _, item := range d.Value.([]interface{}) {
-		sprint := item.(map[string]interface{})
-		sprintIds = append(sprintIds, sprint["id"])
+		if sprint, ok := item.(map[string]interface{}); ok {
+			sprintIds = append(sprintIds, sprint["id"])
+		}
 	}
 
 	return sprintIds, nil
@@ -381,8 +382,9 @@ func extractSprintNames(ctx context.Context, d *transform.TransformData) (interf
 	}
 	var sprintNames []interface{}
 	for _, item := range d.Value.([]interface{}) {
-		sprint := item.(map[string]interface{})
-		sprintNames = append(sprintNames, sprint["name"])
+		if sprint, ok := item.(map[string]interface{}); ok {
+			sprintNames = append(sprintNames, sprint["name"])
+		}
 	}
 
 	return sprintNames, nil


### PR DESCRIPTION
There is an error with some queries because the Jira issue contains a `string` sprint instead of a map:
```
❯ steampipe query "select key, self, project_key from jira_issue where project_key = 'MYPROJECT' limit 5000;"

Error: failed to populate column 'sprint_ids': rpc error: code = Internal desc = transform extractSprintIds failed with panic interface conversion: interface {} is string, not map[string]interface {} (SQLSTATE HV000)

+-----+------+-------------+
| key | self | project_key |
+-----+------+-------------+
+-----+------+-------------+
```
These changes ignore invalid types such as `string` and just store the valid values.