### PR TITLE
JQL search on jira_issue table is case sensitive while the JIRA API is not Closes #85

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -81,7 +81,8 @@ func tableIssue(_ context.Context) *plugin.Table {
 				Name:        "status",
 				Description: "Json object containing important subfields info the issue.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Fields.Status.Name"),
+				Hydrate:     getStatusValue,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "status_category",
@@ -344,6 +345,16 @@ func getIssue(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 	}
 
 	return IssueInfo{*issue, keys}, err
+}
+
+func getStatusValue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	issue := h.Item.(IssueInfo)
+	issueStauus := d.EqualsQualString("status")
+
+	if issueStauus != "" {
+		return issueStauus, nil
+	}
+	return issue.Fields.Status, nil
 }
 
 //// TRANSFORM FUNCTION

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -354,7 +354,7 @@ func getStatusValue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 	if issueStauus != "" {
 		return issueStauus, nil
 	}
-	return issue.Fields.Status, nil
+	return issue.Fields.Status.Name, nil
 }
 
 //// TRANSFORM FUNCTION


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
**Before fix:**

> select * from jira_issue where status='to Do' limit 10
+----+-----+------+-------------+------------+--------+-----------------+----------+------------+--------------+---------------------+-----------------------+--------------------+----------------------+->
| id | key | self | project_key | project_id | status | status_category | epic_key | sprint_ids | sprint_names | assignee_account_id | assignee_display_name | creator_account_id | creator_display_name | >
+----+-----+------+-------------+------------+--------+-----------------+----------+------------+--------------+---------------------+-----------------------+--------------------+----------------------+->
+----+-----+------+-------------+------------+--------+-----------------+----------+------------+--------------+---------------------+-----------------------+--------------------+----------------------+->

**After Fix:**

> select * from jira_issue where status='resolved' limit 10
+-------+--------+------------------------------------------------------+-------------+------------+----------+-----------------+----------+------------+--------------+----------------------------------->
| id    | key    | self                                                 | project_key | project_id | status   | status_category | epic_key | sprint_ids | sprint_names | assignee_account_id               >
+-------+--------+------------------------------------------------------+-------------+------------+----------+-----------------+----------+------------+--------------+----------------------------------->
| 10004 | DESK-5 | https://turbi63.atlassian.net/rest/api/2/issue/10004 | DESK        | 10001      | resolved | Done            | <null>   | <null>     | <null>       | 712020:5dab9f7f-a163-4a8e-86ff-68c>
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
|       |        |                                                      |             |            |          |                 |          |            |              |                                   >
+-------+--------+------------------------------------------------------+-------------+------------+----------+-----------------+----------+------------+--------------+----------------------------------->

> select * from jira_issue where status='to do' limit 10
+-------+-------+------------------------------------------------------+-------------+------------+--------+-----------------+----------+------------+--------------+---------------------+---------------->
| id    | key   | self                                                 | project_key | project_id | status | status_category | epic_key | sprint_ids | sprint_names | assignee_account_id | assignee_displa>
+-------+-------+------------------------------------------------------+-------------+------------+--------+-----------------+----------+------------+--------------+---------------------+---------------->
| 10007 | TES-1 | https://turbi63.atlassian.net/rest/api/2/issue/10007 | TES         | 10000      | to do  | To Do           | <null>   | <null>     | <null>       | <null>              | <null>         >
|       |       |                                                      |             |            |        |                 |          |            |              |                     |                >
|       |       |                                                      |             |            |        |                 |          |            |              |                     |                >
|       |       |                                                      |             |            |        |                 |          |            |              |                     |                >
|       |       |                                                      |             |            |        |                 |          |            |              |                     |                >
|       |       |                                                      |             |            |        |                 |          |            |              |                     |                >
|       |       |                                                      |             |            |        |                 |          |            |              |                     |                >
+-------+-------+------------------------------------------------------+-------------+------------+--------+-----------------+----------+------------+--------------+---------------------+---------------->

```
</details>
