### PR TITLE
Add a limit of 500 issues

### DIFF
--- a/config/jira.spc
+++ b/config/jira.spc
@@ -19,4 +19,8 @@ connection "jira" {
   # Can also be set with the `JIRA_PERSONAL_ACCESS_TOKEN` environment variable.
   # Personal Access Token can only be used to query jira_backlog_issue, jira_board, jira_issue and jira_sprint tables.
   # personal_access_token = "MDU0MDMx7cE25TQ3OujDfy/vkv/eeSXXoh/zXY1ex9cp"
+
+  # Pagination size for the jira search API
+  # Default is 50, max is 100.
+  # page_size = 50
 }

--- a/jira/connection_config.go
+++ b/jira/connection_config.go
@@ -10,6 +10,7 @@ type jiraConfig struct {
 	Username            *string `cty:"username"`
 	Token               *string `cty:"token"`
 	PersonalAccessToken *string `cty:"personal_access_token"`
+	PageSize            *int    `cty:"page_size"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -24,6 +25,9 @@ var ConfigSchema = map[string]*schema.Attribute{
 	},
 	"personal_access_token": {
 		Type: schema.TypeString,
+	},
+	"page_size": {
+		Type: schema.TypeInt,
 	},
 }
 

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -241,13 +241,19 @@ func tableIssue(_ context.Context) *plugin.Table {
 func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 
 	last := 0
+	pageSize, err := getPageSize(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("jira_issue.listIssues", "page_size", err)
+		return nil, err
+	}
+	plugin.Logger(ctx).Debug("jira_issue.listIssues", "page_size", pageSize)
 
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead
 	queryLimit := d.QueryContext.Limit
-	var limit int = 50
+	var limit int = pageSize
 	if d.QueryContext.Limit != nil {
-		if *queryLimit < 50 {
+		if *queryLimit < int64(limit) {
 			limit = int(*queryLimit)
 		}
 	}

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -242,6 +242,8 @@ func tableIssue(_ context.Context) *plugin.Table {
 func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 
 	last := 0
+	issueCount := 1
+	issueLimit := 500
 	pageSize, err := getPageSize(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("jira_issue.listIssues", "page_size", err)
@@ -287,6 +289,10 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 		}
 
 		for _, issue := range issues {
+			if issueCount > issueLimit {
+				plugin.Logger(ctx).Debug("Maximum number of issues reached", issueLimit)
+				return nil, nil
+			}
 			plugin.Logger(ctx).Debug("Issue output:", issue)
 			plugin.Logger(ctx).Debug("Issue names output:", names)
 			keys := map[string]string{
@@ -298,6 +304,7 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 			if d.RowsRemaining(ctx) == 0 {
 				return nil, nil
 			}
+			issueCount += 1
 		}
 
 		last = searchResult.StartAt + len(issues)

--- a/jira/utils.go
+++ b/jira/utils.go
@@ -158,3 +158,18 @@ func buildJQLQueryFromQuals(equalQuals plugin.KeyColumnQualMap, tableColumns []*
 func getIssueJQLKey(columnName string) string {
 	return strings.ToLower(strings.Split(columnName, "_")[0])
 }
+
+func getPageSize(_ context.Context, d *plugin.QueryData) (int, error) {
+	jiraConfig := GetConfig(d.Connection)
+
+	pageSize := 50
+	if jiraConfig.PageSize != nil {
+		pageSize = *jiraConfig.PageSize
+	}
+
+	if pageSize < 1 || pageSize > 100 {
+		return -1, errors.New("'page_size' must be set to 1 to 100 in the connection configuration. Edit your connection configuration file and then restart Steampipe")
+	}
+
+	return pageSize, nil
+}


### PR DESCRIPTION
We want to limit the number of results returned by queries to 500 issues.