### PR TITLE
Fixed table jira_board only fetching first page of results Closes #126

### DIFF
--- a/jira/table_jira_board.go
+++ b/jira/table_jira_board.go
@@ -91,6 +91,7 @@ func listBoards(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 			maxResults = int(*queryLimit)
 		}
 	}
+
 	for {
 		opt := jira.SearchOptions{
 			MaxResults: maxResults,
@@ -107,8 +108,6 @@ func listBoards(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 			return nil, err
 		}
 
-		total := res.Total
-
 		for _, board := range boardList.Values {
 			d.StreamListItem(ctx, board)
 			// Context may get cancelled due to manual cancellation or if the limit has been reached
@@ -117,8 +116,8 @@ func listBoards(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 			}
 		}
 
-		last = res.StartAt + len(boardList.Values)
-		if last >= total {
+		last = boardList.StartAt + len(boardList.Values)
+		if last >= boardList.Total {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select id, name, type from jira_board
+----+----------------+--------+
| id | name           | type   |
+----+----------------+--------+
| 1  | TEST board     | simple |
| 3  | TUTORIAL board | simple |
| 2  | SSP board      | scrum  |
| 4  | TEST1 board    | scrum  |
| 5  | USERMGMT board | kanban |
+----+----------------+--------+

Time: 1.3s. Rows returned: 5. Rows fetched: 5. Hydrate calls: 0.
```
</details>
