### PR TITLE
plugin name must be quoted

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Configure your account details in `~/.steampipe/config/jira.spc`:
 
 ```hcl
 connection "jira" {
-  plugin = jira
+  plugin = "jira"
 
   # Authentication information
   base_url              = "https://your-domain.atlassian.net/"


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
