### PR TITLE
Update jira_issue_worklog table design to avoid API calls to list issues if issue_id is provided in query parameter

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -485,6 +485,31 @@ func searchWithContext(ctx context.Context, d *plugin.QueryData, jql string, opt
 	return v, resp, err
 }
 
+//// PARENT HYDRATE
+
+// The Steampipe SDK is yet to support making API calls conditionally based on query parameters.
+// For example, when running the query "SELECT * FROM jira_issue_comment WHERE issue_id = '10037';"
+// we should avoid making an API call to fetch all issues because issue_id is provided in the query parameter, even though jira_issue is the parent of jira_issue_comment.
+// However, for a query like "SELECT * FROM jira_issue_comment", we should first retrieve all issues
+// and then fetch the comments for each issue.
+func listIssuesForIssueChildren(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	issueId := d.EqualsQualString("issue_id")
+
+	if issueId != "" {
+		item := IssueInfo{
+			Issue: jira.Issue{
+				ID: issueId,
+			},
+		}
+
+		d.StreamListItem(ctx, item)
+
+		return nil, nil
+	}
+
+	return listIssues(ctx, d, h)
+}
+
 //// Required Structs
 
 type ListIssuesResult struct {

--- a/jira/table_jira_issue_comment.go
+++ b/jira/table_jira_issue_comment.go
@@ -3,7 +3,6 @@ package jira
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -158,7 +157,7 @@ func listIssueComments(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		comments := new(CommentResult)
 		_, err = client.Do(req, comments)
 		if err != nil {
-			if strings.Contains(err.Error(), "404") { // Handle not found error code
+			if isNotFoundError(err) { // Handle not found error code
 				return nil, nil
 			}
 			plugin.Logger(ctx).Error("jira_issue_comment.listIssueComments", "api_error", err)

--- a/jira/table_jira_issue_comment.go
+++ b/jira/table_jira_issue_comment.go
@@ -23,7 +23,7 @@ func tableIssueComment(_ context.Context) *plugin.Table {
 			Hydrate:    getIssueComment,
 		},
 		List: &plugin.ListConfig{
-			ParentHydrate: listIssuesForIssueComment,
+			ParentHydrate: listIssuesForIssueChildren,
 			Hydrate:       listIssueComments,
 			KeyColumns: plugin.KeyColumnSlice{
 				{Name: "issue_id", Require: plugin.Optional},
@@ -218,29 +218,3 @@ func getIssueComment(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 
 	return commentWithIssueDetails{*res, issueId}, nil
 }
-
-//// PARENT HYDRATE
-
-// The Steampipe SDK is yet to support making API calls conditionally based on query parameters.
-// For example, when running the query "SELECT * FROM jira_issue_comment WHERE issue_id = '10037';" 
-// we should avoid making an API call to fetch all issues because issue_id is provided in the query parameter, even though jira_issue is the parent of jira_issue_comment.
-// However, for a query like "SELECT * FROM jira_issue_comment", we should first retrieve all issues 
-// and then fetch the comments for each issue.
-func listIssuesForIssueComment(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	issueId := d.EqualsQualString("issue_id")
-
-	if issueId != "" {
-		item := IssueInfo{
-			Issue: jira.Issue{
-				ID: issueId,
-			},
-		}
-
-		d.StreamListItem(ctx, item)
-		
-		return nil, nil
-	}
-	
-	return listIssues(ctx, d, h)
-}
-

--- a/jira/table_jira_issue_worklog.go
+++ b/jira/table_jira_issue_worklog.go
@@ -3,7 +3,6 @@ package jira
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
@@ -156,7 +155,7 @@ func listIssueWorklogs(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		w := new(jira.Worklog)
 		_, err = client.Do(req, w)
 		if err != nil {
-			if strings.Contains(err.Error(), "404") { // Handle not found error code
+			if isNotFoundError(err) { // Handle not found error code
 				return nil, nil
 			}
 


### PR DESCRIPTION
See https://github.com/turbot/steampipe-plugin-jira/pull/143

This PR applies same fix but to jira_issue_worklog table.

One small note: I noticed that for Get.KeyColumns, AnyColumns is used instead of AllColumns. I believe for successfully getting worklog, both are required as per API design https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-worklogs/#api-rest-api-2-issue-issueidorkey-worklog-id-get

Results:

Now:
```
select id from jira_issue_worklog where issue_id = 'JIRA-100';
+-------+
| id    |
+-------+
| 12942 |
+-------+

Time: 278ms. Rows returned: 0. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) jira_issue_worklog.jira: Time: 225ms. Fetched: 1. Hydrates: 0. Quals: issue_id=JIRA-100.
```

Earlier:

No results (timeout) due to number of issues fetched
