### PR TITLE
Add changelog column to jira_issues

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -220,6 +220,11 @@ func tableIssue(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "changelog",
+				Description: "Json object containing changelog of the issue.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "tags",
 				Type:        proto.ColumnType_JSON,
 				Description: "A map of label names associated with this issue, in Steampipe standard format.",
@@ -255,7 +260,7 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	options := jira.SearchOptions{
 		StartAt:    0,
 		MaxResults: limit,
-		Expand:     "names",
+		Expand:     "names,changelog",
 	}
 
 	jql := ""
@@ -335,7 +340,7 @@ func getIssue(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 	}
 
 	issue, res, err := client.Issue.Get(id, &jira.GetQueryOptions{
-		Expand: "names",
+		Expand: "names,changelog",
 	})
 	body, _ := io.ReadAll(res.Body)
 	plugin.Logger(ctx).Debug("jira_issue.getIssue", "res_body", string(body))

--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -221,7 +221,7 @@ func tableIssue(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "changelog",
-				Description: "Json object containing changelog of the issue.",
+				Description: "JSON object containing changelog of the issue.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
SELECT LEFT(changelog::text, 21) AS changelog FROM jira_issue WHERE key='JIRA-120'
```
</details>

Returns changelog (JSON)

```
+-----------------------+
| changelog             |
+-----------------------+
| {"histories": [{"id": |
+-----------------------+
```