### PR TITLE
jira_issue_worklogs: use updated to get worklogs

### DIFF
--- a/jira/table_jira_issue_worklog.go
+++ b/jira/table_jira_issue_worklog.go
@@ -257,6 +257,7 @@ func listWorklogsByUpdated(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 			// Extract the path from the full URL using the url package
 			parsedUrl, err := url.Parse(nextPageUrl)
 			if err != nil {
+				plugin.Logger(ctx).Error("jira_issue_worklog.listWorklogsByUpdated", "parsing_error", err)
 				return nil, err
 			}
 			nextPageUrl = parsedUrl.Path + "?" + parsedUrl.RawQuery

--- a/jira/table_jira_issue_worklog.go
+++ b/jira/table_jira_issue_worklog.go
@@ -238,7 +238,8 @@ func listWorklogsByUpdated(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		}
 
 		// no need to worry about pagination in batchGetWorklog
-		// since it accepts same number of worklogs per page as this method
+		// since it accepts same number of worklogs per page (1000)
+		// as this method returns at maximum (also 1000)
 		_, err = batchGetWorklog(ctx, worklogIds, d)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select count(*) from jira_issue_worklog
+-------+
| count |
+-------+
| 1913  |
+-------+

Time: 15.7s. Rows returned: 0. Rows fetched: 1,913. Hydrate calls: 0.
```
```
> select count(*) from jira_issue_worklog where issue_id = '2261424';
+-------+
| count |
+-------+
| 1     |
+-------+

Time: 397ms. Rows returned: 0. Rows fetched: 1. Hydrate calls: 0.
```

```
> select count(*) from jira_issue_worklog where updated > '2025-01-01 00:00:00'::timestamptz;
+-------+
| count |
+-------+
| 313   |
+-------+

Time: 3.6s. Rows returned: 0. Rows fetched: 313. Hydrate calls: 0.
```
</details>

This PR improves the worklog retrieval functionality by filtering on the updated field, leading to more efficient queries such as:

`select count(*) from jira_issue_worklog where updated > '2025-01-01 00:00:00'::timestamptz`

Key changes include:

* Efficient querying based on the updated field.
* Removal of the ParentHydrate dependency from jira_issue_worklog.
* Note: When an issue_id is not provided, the default filter (updated > 0) allows fetching all worklog entries.

This update may also make issue #148 redundant.