### PR TITLE
Remap resolutiondate and statuscategory for jql usage

### DIFF
--- a/jira/utils.go
+++ b/jira/utils.go
@@ -161,5 +161,13 @@ func buildJQLQueryFromQuals(equalQuals plugin.KeyColumnQualMap, tableColumns []*
 }
 
 func getIssueJQLKey(columnName string) string {
+	remappedColumns := map[string]string{
+		"resolution_date": "resolutiondate",
+		"status_category": "statuscategory",
+	}
+
+	if val, ok := remappedColumns[columnName]; ok {
+		return val
+	}
 	return strings.ToLower(strings.Split(columnName, "_")[0])
 }


### PR DESCRIPTION
Fixes #145

# Example query results
<details>
  <summary>Results</summary>
  
```
SELECT key, status_category FROM jira_issue WHERE status_category = 'Done' AND resolution_date >= (now() - '2 weeks'::interval)::timestamptz
```
</details>
