### PR TITLE
Fix jira_issue_worklog to correctly populate issue_id when provided as a query parameter

### DIFF
--- a/jira/table_jira_issue_worklog.go
+++ b/jira/table_jira_issue_worklog.go
@@ -171,7 +171,7 @@ func listIssueWorklogs(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 		}
 
 		for _, c := range w.Worklogs {
-			d.StreamListItem(ctx, WorklogDetails{c, issueId})
+			d.StreamListItem(ctx, WorklogDetails{c, c.IssueID})
 
 			// Context may get cancelled due to manual cancellation or if the limit has been reached
 			if d.RowsRemaining(ctx) == 0 {


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from jira_issue_worklog where issue_id = '10041';
+---------------------------------------------+-------+----------+--------------------------------------------------------------------------+---------+---------------------------+---------------------------+---------------------------+------------+------>
| login_id                                    | id    | issue_id | self                                                                     | comment | started                   | created                   | updated                   | time_spent | time_>
+---------------------------------------------+-------+----------+--------------------------------------------------------------------------+---------+---------------------------+---------------------------+---------------------------+------------+------>
| 712020:3cf24750-73fe-4040-bdbe-07f73135aec2 | 10000 | 10041    | https://turbot-turbot.atlassian.net/rest/api/2/issue/10041/worklog/10000 |         | 2025-02-19T12:27:44+05:30 | 2025-02-19T12:32:54+05:30 | 2025-02-19T12:32:54+05:30 | 5m         | 300  >
|                                             |       |          |                                                                          |         |                           |                           |                           |            |      >
+---------------------------------------------+-------+----------+--------------------------------------------------------------------------+---------+---------------------------+---------------------------+---------------------------+------------+------>

Time: 2.7s. Rows returned: 0. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) jira_issue_worklog.jira: Time: 2.6s. Fetched: 1. Hydrates: 1. Quals: issue_id=10041.

> select * from jira_issue_worklog where issue_id = 'TEST6-3';
+----------+----+----------+------+---------+---------+---------+---------+------------+--------------------+------------+--------+---------------+-------+--------------------+--------+------+
| login_id | id | issue_id | self | comment | started | created | updated | time_spent | time_spent_seconds | properties | author | update_author | title | sp_connection_name | sp_ctx | _ctx |
+----------+----+----------+------+---------+---------+---------+---------+------------+--------------------+------------+--------+---------------+-------+--------------------+--------+------+
+----------+----+----------+------+---------+---------+---------+---------+------------+--------------------+------------+--------+---------------+-------+--------------------+--------+------+

Time: 0.7s. Rows returned: 0. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) jira_issue_worklog.jira: Time: 0.6s. Fetched: 1. Hydrates: 1. Quals: issue_id=TEST6-3.
```
</details>
