### PR TITLE
Fix missing custom fields (Should close #182)

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -225,7 +225,7 @@ func tableIssue(_ context.Context) *plugin.Table {
 				Name:        "fields",
 				Description: "Json object containing important subfields of the issue.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("V3Issue.Fields"),
+				Transform:   transform.FromField("V3Issue.Fields.RawFields"),
 			},
 			{
 				Name:        "changelog",


### PR DESCRIPTION
This should close https://github.com/turbot/steampipe-plugin-jira/issues/182, but it's a breaking change. It brings the Jira custom fields back to the `fields` column, but it stops aggregating them in an `Unknowns` object. 