### PR TITLE
Fix missing custom fields in `jira_issue` when using JQL

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -386,7 +386,7 @@ func getRequiredFields(ctx context.Context, d *plugin.QueryData) []string {
 		"work_log":   "worklog",
 
 		// JSON fields that need the full field object
-		"fields": "", // Need all fields for this
+		"fields": "*all", // Need all fields for this
 
 		// Custom fields that require *all
 		"epic_key":     "", // Requires custom field access


### PR DESCRIPTION
This is a follow-up of #183. The `custom_fields` were still missing if the query used JQL instead of filtering for a specific key. 

Fixed by adding `*all` as the default value in the `requestBody` for `fields`, as required by the [new API endpoints]:(https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get-request-Query%20parameters): 
> Note: By default, this resource returns IDs only. This differs from [GET issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get) where the default is all fields.

Previously, all the fields would be returned by default if the `fields` key was sent empty (similarly to what happens when getting a specific ticket as quoted above). 

Apologies for not having spotted this during the testing of the previous PR yesterday 🥶

Cc @misraved @ParthaI @dcdamien