### PR TITLE
Fixed empty result returned by jira_issue_comment Closes #188

### DIFF
--- a/jira/table_jira_issue_comment.go
+++ b/jira/table_jira_issue_comment.go
@@ -116,9 +116,6 @@ type commentWithIssueDetails struct {
 //// LIST FUNCTION
 
 func listIssueComments(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	if h.Item == nil {
-		return nil, nil
-	}
 	issueId := d.EqualsQualString("issue_id")
 
 	// Minize the API call for given issue ID.


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from jira_issue_comment where issue_id = '43589'
+---------------------------------------------+-------+----------+--------------------------------------------------------------------------+------------------------------------------------+---------------------------+---------------------------+------------+---------->
| login_id                                    | id    | issue_id | self                                                                     | body                                           | created                   | updated                   | jsd_public | author   >
+---------------------------------------------+-------+----------+--------------------------------------------------------------------------+------------------------------------------------+---------------------------+---------------------------+------------+---------->
| 712020:3cf24750-73fe-4040-bdbe-07f73135aec2 | 42581 | 43589    | https://turbot-turbot.atlassian.net/rest/api/2/issue/43589/comment/42581 | Bulk demo comment for issue #497 added via API | 2025-09-04T20:57:53+05:30 | 2025-09-04T20:57:53+05:30 | true       | {"account>
|                                             |       |          |                                                                          |                                                |                           |                           |            | 2","timeZ>
| 712020:3cf24750-73fe-4040-bdbe-07f73135aec2 | 49581 | 43589    | https://turbot-turbot.atlassian.net/rest/api/2/issue/43589/comment/49581 | hey is this still WIP                          | 2025-09-29T16:16:53+05:30 | 2025-09-29T16:16:53+05:30 | true       | {"account>
|                                             |       |          |                                                                          |                                                |                           |                           |            | e":"Asia/>
+---------------------------------------------+-------+----------+--------------------------------------------------------------------------+------------------------------------------------+---------------------------+---------------------------+------------+---------->

```
</details>
